### PR TITLE
Implement Collatz Conjecture Tower

### DIFF
--- a/Includes/CubbyTower/Commons/TowerData.hpp
+++ b/Includes/CubbyTower/Commons/TowerData.hpp
@@ -14,6 +14,9 @@ constexpr static int ARROW_TOWER_LV1_PRICE = 100;
 
 //! The price of arrow tower at level 2.
 constexpr static int ARROW_TOWER_LV2_PRICE = 200;
+
+//! The price of collatz tower.
+constexpr static int COLLATZ_TOWER_PRICE = 500;
 }  // namespace CubbyTower
 
 #endif  // CUBBYTOWER_TOWER_DATA_HPP

--- a/Includes/CubbyTower/Components/CollatzDamage.hpp
+++ b/Includes/CubbyTower/Components/CollatzDamage.hpp
@@ -4,8 +4,8 @@
 // personal capacity and are not conveying any rights to any intellectual
 // property of any third parties.
 
-#ifndef CUBBYTOWER_COLLATZDAMAGE_HPP
-#define CUBBYTOWER_COLLATZDAMAGE_HPP
+#ifndef CUBBYTOWER_COLLATZ_DAMAGE_HPP
+#define CUBBYTOWER_COLLATZ_DAMAGE_HPP
 
 namespace CubbyTower
 {
@@ -20,4 +20,4 @@ struct CollatzDamage
 };
 }  // namespace CubbyTower
 
-#endif  // CUBBYTOWER_DAMAGE_HPP
+#endif  // CUBBYTOWER_COLLATZ_DAMAGE_HPP

--- a/Includes/CubbyTower/Components/CollatzDamage.hpp
+++ b/Includes/CubbyTower/Components/CollatzDamage.hpp
@@ -1,0 +1,23 @@
+// Copyright (c) 2021 CubbyTower Team
+// Chris Ohk, Minkyu Lee, Minjune Yi
+// We are making my contributions/submissions to this project solely in our
+// personal capacity and are not conveying any rights to any intellectual
+// property of any third parties.
+
+#ifndef CUBBYTOWER_COLLATZDAMAGE_HPP
+#define CUBBYTOWER_COLLATZDAMAGE_HPP
+
+namespace CubbyTower
+{
+//!
+//! \brief Damage struct for Collatz tower.
+//!
+//! This struct stores the max damage of the tower.
+//!
+struct CollatzDamage
+{
+    int maxDamage;
+};
+}  // namespace CubbyTower
+
+#endif  // CUBBYTOWER_DAMAGE_HPP

--- a/Includes/CubbyTower/Helpers/ShootingHelpers.hpp
+++ b/Includes/CubbyTower/Helpers/ShootingHelpers.hpp
@@ -28,8 +28,7 @@ void CreateArrow(entt::registry& registry, const Position& from,
 //! \param registry A registry that handles entities.
 //! \param from The start position of the collatz for the collatz tower.
 //! \param to The end position of the collatz for target.
-//! \param collatzDamage Handle information about the collatz entity should give
-//! damage
+//! \param collatzDamage The amount of collatz damage to give.
 void CreateCollatz(entt::registry& registry, const Position& from,
                    const Position& to, CollatzDamage collatzDamage);
 

--- a/Includes/CubbyTower/Helpers/ShootingHelpers.hpp
+++ b/Includes/CubbyTower/Helpers/ShootingHelpers.hpp
@@ -24,6 +24,15 @@ namespace Shooting
 void CreateArrow(entt::registry& registry, const Position& from,
                  const Position& to, int damage);
 
+//! Creates an Collatz entity to shoot a target.
+//! \param registry A registry that handles entities.
+//! \param from The start position of the collatz for the collatz tower.
+//! \param to The end position of the collatz for target.
+//! \param collatzDamage Handle information about the collatz entity should give
+//! damage
+void CreateCollatz(entt::registry& registry, const Position& from,
+                   const Position& to, CollatzDamage collatzDamage);
+
 //! Gives a damage to a target.
 //! \param registry A registry that handles entities.
 //! \param target A target that takes a damage.

--- a/Includes/CubbyTower/Helpers/TowerHelpers.hpp
+++ b/Includes/CubbyTower/Helpers/TowerHelpers.hpp
@@ -48,6 +48,13 @@ void ShootArrowLv1(entt::registry& registry, entt::entity target,
 void ShootArrowLv2(entt::registry& registry, entt::entity target,
                    entt::entity from);
 
+// Shoots a collatz instance for collatz tower.
+//! \param registry A registry that handles entities.
+//! \param target A target entity to shoot.
+//! \param from A tower entity that shoots collatz instance.
+void ShootCollatz(entt::registry& registry, entt::entity target,
+                  entt::entity from);
+
 //! Finds a first target within a range.
 //! \param registry A registry that handles entities.
 //! \return a first target if it is within a range, entt::null otherwise.

--- a/Includes/CubbyTower/Helpers/TowerHelpers.hpp
+++ b/Includes/CubbyTower/Helpers/TowerHelpers.hpp
@@ -48,6 +48,11 @@ void ShootArrowLv1(entt::registry& registry, entt::entity target,
 void ShootArrowLv2(entt::registry& registry, entt::entity target,
                    entt::entity from);
 
+//! Buys a collatz tower.
+//! \param registry A registry that handles entities.
+//! \param position The position to place a collatz tower.
+void BuyCollatzTower(entt::registry& registry, const Position& position);
+
 // Shoots a collatz instance for collatz tower.
 //! \param registry A registry that handles entities.
 //! \param target A target entity to shoot.

--- a/Sources/CubbyTower/Game.cpp
+++ b/Sources/CubbyTower/Game.cpp
@@ -137,6 +137,12 @@ void Initialize(entt::registry& registry)
             [](entt::registry& registry, entt::entity button) {
                 Tower::CreatePlacer(registry, Tower::BuyArrowTower);
             });
+
+        UI::CreateTowerButton(
+            registry, "Collatz Tower", { -1, 15.5f }, COLLATZ_TOWER_PRICE,
+            [](entt::registry& registry, entt::entity button) {
+                Tower::CreatePlacer(registry, Tower::BuyCollatzTower);
+            });
     }
 }
 

--- a/Sources/CubbyTower/Helpers/ShootingHelpers.cpp
+++ b/Sources/CubbyTower/Helpers/ShootingHelpers.cpp
@@ -73,15 +73,16 @@ static void OnCollideCollatz(entt::registry& registry, entt::entity entity)
             if (dist < 0.5f)
             {
                 int damage = collatzDamage.maxDamage;
+                
                 if (health.curAmount % 2 == 0)
                 {
-                    if (damage > health.curAmount / 2)
-                        damage = health.curAmount / 2;
+                    damage = std::min(damage, health.curAmount / 2);
                 }
                 else
                 {
                     damage = -(health.curAmount * 2 + 1);
                 }
+                
                 GiveDamage(registry, entity, damage);
             }
         });
@@ -138,8 +139,7 @@ void GiveDamage(entt::registry& registry, entt::entity& target, int damage)
 
     auto& health = registry.get<Health>(target);
     health.curAmount -= damage;
-    if (health.curAmount > health.maxAmount)
-        health.curAmount = health.maxAmount;
+    health.curAmount = std::min(health.curAmount, health.maxAmount);
 
     if (health.curAmount <= 0)
     {

--- a/Sources/CubbyTower/Helpers/ShootingHelpers.cpp
+++ b/Sources/CubbyTower/Helpers/ShootingHelpers.cpp
@@ -72,7 +72,6 @@ static void OnCollideCollatz(entt::registry& registry, entt::entity entity)
 
             if (dist < 0.5f)
             {
-                auto health = registry.get<Health>(entity);
                 int damage = collatzDamage.maxDamage;
                 if (health.curAmount % 2 == 0)
                 {

--- a/Sources/CubbyTower/Helpers/ShootingHelpers.cpp
+++ b/Sources/CubbyTower/Helpers/ShootingHelpers.cpp
@@ -113,6 +113,23 @@ void CreateArrow(entt::registry& registry, const Position& from,
     registry.emplace<Damage>(entity, damage);
 }
 
+void CreateCollatz(entt::registry& registry, const Position& from,
+                   const Position& to, CollatzDamage collatzDamage)
+{
+    const float dx = to.x - from.x;
+    const float dy = to.y - from.y;
+    const float len = std::sqrt(dx * dx + dy * dy);
+
+    auto entity = registry.create();
+    registry.emplace<Position>(entity, from);
+    registry.emplace<PositionAnim>(entity, from, to, 0.0f, len / 10.0f,
+                                   OnCollideCollatz);
+    registry.emplace<ShapeRenderer>(entity, Shape::DrawBox);
+    registry.emplace<Size>(entity, 0.15f, 0.15f);
+    registry.emplace<Color>(entity, Color{ 0.0f, 1.0f, 1.0f, 1.0f });
+    registry.emplace<CollatzDamage>(entity, collatzDamage);
+}
+
 void GiveDamage(entt::registry& registry, entt::entity& target, int damage)
 {
     if (!registry.all_of<Health>(target))

--- a/Sources/CubbyTower/Helpers/TowerHelpers.cpp
+++ b/Sources/CubbyTower/Helpers/TowerHelpers.cpp
@@ -7,6 +7,7 @@
 #include <CubbyTower/Commons/Constants.hpp>
 #include <CubbyTower/Commons/Tags.hpp>
 #include <CubbyTower/Commons/TowerData.hpp>
+#include <CubbyTower/Components/CollatzDamage.hpp>
 #include <CubbyTower/Components/Color.hpp>
 #include <CubbyTower/Components/FindTarget.hpp>
 #include <CubbyTower/Components/Hoverable.hpp>
@@ -89,6 +90,15 @@ void ShootArrowLv2(entt::registry& registry, entt::entity target,
                    entt::entity from)
 {
     // Do nothing
+}
+
+void ShootCollatz(entt::registry& registry, entt::entity target,
+                  entt::entity from)
+{
+    Shooting::CreateCollatz(registry, registry.get<Position>(from),
+                            registry.get<Position>(target),
+                            CollatzDamage{ 100 });
+    Audio::PlaySound("arrow");
 }
 
 entt::entity FindFirstTarget(entt::registry& registry)

--- a/Sources/CubbyTower/Helpers/TowerHelpers.cpp
+++ b/Sources/CubbyTower/Helpers/TowerHelpers.cpp
@@ -92,6 +92,30 @@ void ShootArrowLv2(entt::registry& registry, entt::entity target,
     // Do nothing
 }
 
+void BuyCollatzTower(entt::registry& registry, const Position& position)
+{
+    // Check the player can buy arrow tower
+    if (!Bank::Withdraw(registry, registry.view<Tag::Player>()[0],
+                        COLLATZ_TOWER_PRICE))
+    {
+        return;
+    }
+
+    auto entity = registry.create();
+    registry.emplace<Tag::Tower>(entity);
+    registry.emplace<Position>(entity, position);
+    registry.emplace<Size>(entity, TOWER_SIZE, TOWER_SIZE);
+    registry.emplace<Color>(entity, TOWER_LEVEL1_COLOR);
+    registry.emplace<TextRenderer>(entity, "C", Color{ 0.0f, 0.0f, 0.0f, 0.0f },
+                                   0.5f);
+    registry.emplace<ShapeRenderer>(entity, Shape::DrawBox);
+    registry.emplace<Name>(entity, "Collatz Tower(WIP)");
+    registry.emplace<Targeter>(entity, TargetMask{ GROUND | AIR },
+                               210.0f / 60.0f, 1.0f, ShootCollatz);
+    registry.emplace<Hoverable>(entity);
+    registry.emplace<FindTarget>(entity, FindFirstTarget);
+}
+
 void ShootCollatz(entt::registry& registry, entt::entity target,
                   entt::entity from)
 {


### PR DESCRIPTION
콜라츠 추측 타워를 구현하는 것이 목표인 PR입니다.

- 콜라츠 추측 방식으로 데미지를 주는 타워 구현
- 타워 생성 버튼 구현
- 콜라츠 타워를 위한 데미지 컴포넌트 생성

추가적인 해야 할 일은 다음과 같습니다.
- 테스트케이스 생성
- 업그레이드 적용(콜라츠 타워의 회복량의 최솟값이 생기는 업그레이드 같은 것들) -> 데미지 컴포넌트의 추가적인 수정이 필요합니다.